### PR TITLE
fix: missing npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "webpack-dev-server --mode development",
     "transpile": "babel src -d dist --copy-files",
     "prepublishOnly": "npm run transpile",
+    "prepare": "npm run transpile && npm run build",
     "build": "webpack --mode production",
     "deploy": "gh-pages -d examples/dist",
     "publish-demo": "npm run build && npm run deploy"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import "./index.css";
+//import "./index.css";
 import { applyStyle } from "./applyStyle";
 
 class WheelPicker extends React.Component {


### PR DESCRIPTION
I tried to import your library into my NextJS project. However, I got the error "Can't resolve 'react-wheelpicker'" in my environment.

## Fixes.
### Comment out CSS import.
NextJS does not allow CSS import outside of "_app.js", so I commented it out once.
If you write import 'react-wheelpicker/dist/index.css' in "_app.js" separately, the styles are applied.

### Fixed missing npm scripts.
The "prepare" command seems to be executed when installing npm, but "transpile" and "build" were not executed, so I added them.

I'm not familiar with publishing npm modules, so I'm sorry if I'm saying something wrong. Thanks for the good library.

Translated with www.DeepL.com/Translator